### PR TITLE
Suggest renaming stub() / stubbed() to register() / invoke()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ import Stubber
 
 final class StubUserService: UserServiceProtocol {
   func follow(userID: Int) -> String {
-    return Stubber.stubbed(follow, args: userID)
+    return Stubber.invoke(follow, args: userID)
   }
 
   func edit(userID: Int, name: String) -> Bool {
-    return Stubber.stubbed(edit, args: (userID, name))
+    return Stubber.invoke(edit, args: (userID, name))
   }
 }
 
 func testMethodCall() {
   let userService = StubUserService()
-  Stubber.stub(userService.follow) { userID in "stub-\(userID)" } // stub
+  Stubber.register(userService.follow) { userID in "stub-\(userID)" } // stub
   Stubber.follow(userID: 123) // call
   XCTAssertEqual(Stubber.executions(userService.follow).count, 1)
   XCTAssertEqual(Stubber.executions(userService.follow)[0].arguments, 123)

--- a/Sources/Stubber.swift
+++ b/Sources/Stubber.swift
@@ -17,6 +17,11 @@ public func register<A, R>(_ f: (A) -> R, with closure: @escaping (A) -> R) {
   store.executions[address]?.removeAll()
 }
 
+@available(*, deprecated, renamed: "register(_:with:)")
+public func stub<A, R>(_ f: (A) -> R, with closure: @escaping (A) -> R) {
+  register(f, with: closure)
+}
+
 
 // MARK: Stubbed
 
@@ -29,6 +34,12 @@ public func invoke<A, R>(_ f: (A) -> R, args: A, default: @autoclosure () -> R? 
   store.executions[address] = (store.executions[address] ?? []) + [Execution<A, R>(arguments: args, result: result)]
   return result
 }
+
+@available(*, deprecated, renamed: "invoke(_:args:)")
+public func stubbed<A, R>(_ f: (A) -> R, args: A, default: @autoclosure () -> R? = nil, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) -> R {
+  return invoke(f, args: args)
+}
+
 
 
 // MARK: Executions

--- a/Sources/Stubber.swift
+++ b/Sources/Stubber.swift
@@ -11,7 +11,7 @@ private let store = Store()
 
 // MARK: Stub
 
-public func stub<A, R>(_ f: (A) -> R, with closure: @escaping (A) -> R) {
+public func register<A, R>(_ f: (A) -> R, with closure: @escaping (A) -> R) {
   let address = functionAddress(of: f)
   store.stubs[address] = closure
   store.executions[address]?.removeAll()
@@ -20,7 +20,7 @@ public func stub<A, R>(_ f: (A) -> R, with closure: @escaping (A) -> R) {
 
 // MARK: Stubbed
 
-public func stubbed<A, R>(_ f: (A) -> R, args: A, default: @autoclosure () -> R? = nil, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) -> R {
+public func invoke<A, R>(_ f: (A) -> R, args: A, default: @autoclosure () -> R? = nil, file: StaticString = #file, line: UInt = #line, function: StaticString = #function) -> R {
   let address = functionAddress(of: f)
   let closure = store.stubs[address] as? (A) -> R
   guard let result = closure?(args) ?? `default`() else {

--- a/Tests/StubberTests/StubberTests.swift
+++ b/Tests/StubberTests/StubberTests.swift
@@ -10,13 +10,13 @@ class StubberTests: XCTestCase {
   func testExample() {
     let userService = StubUserService()
 
-    Stubber.stub(userService.follow) { userID in "stub-follow-\(userID)" }
+    Stubber.register(userService.follow) { userID in "stub-follow-\(userID)" }
     XCTAssertEqual(userService.follow(userID: 123), "stub-follow-123")
     XCTAssertEqual(Stubber.executions(userService.follow).count, 1)
     XCTAssertEqual(Stubber.executions(userService.follow)[0].arguments, 123)
     XCTAssertEqual(Stubber.executions(userService.follow)[0].result, "stub-follow-123")
 
-    Stubber.stub(userService.follow) { userID in "new-stub-follow-\(userID)" }
+    Stubber.register(userService.follow) { userID in "new-stub-follow-\(userID)" }
     XCTAssertEqual(userService.follow(userID: 456), "new-stub-follow-456")
     XCTAssertEqual(Stubber.executions(userService.follow).count, 1)
     XCTAssertEqual(Stubber.executions(userService.follow)[0].arguments, 456)
@@ -29,8 +29,8 @@ class StubberTests: XCTestCase {
   func testNoArgument() {
     let userService = StubUserService()
     let articleService = StubArticleService()
-    Stubber.stub(userService.foo) { "User" }
-    Stubber.stub(articleService.bar) { "Article" }
+    Stubber.register(userService.foo) { "User" }
+    Stubber.register(articleService.bar) { "Article" }
     XCTAssertEqual(userService.foo(), "User")
     XCTAssertEqual(articleService.bar(), "Article")
     XCTAssertEqual(Stubber.executions(userService.foo).count, 1)
@@ -51,24 +51,24 @@ protocol ArticleServiceType {
 
 final class StubUserService: UserServiceType {
   func foo() -> String {
-    return Stubber.stubbed(foo, args: ())
+    return Stubber.invoke(foo, args: ())
   }
 
   func follow(userID: Int) -> String {
-    return Stubber.stubbed(follow, args: userID)
+    return Stubber.invoke(follow, args: userID)
   }
 
   func unfollow(userID: Int) -> String {
-    return Stubber.stubbed(unfollow, args: userID)
+    return Stubber.invoke(unfollow, args: userID)
   }
 }
 
 final class StubArticleService: ArticleServiceType {
   func bar() -> String {
-    return Stubber.stubbed(bar, args: ())
+    return Stubber.invoke(bar, args: ())
   }
 
   func like(articleID: Int) -> String {
-    return Stubber.stubbed(like, args: articleID)
+    return Stubber.invoke(like, args: articleID)
   }
 }


### PR DESCRIPTION
I suggest this PR because it's a little hard to understand the mechanism of `Stubber` because of these method signatures. 

I think `register()` / `invoke()` signatures can give easier understanding to user programmers than previous pair `stub()` / `stubbed()`, so please consider this suggestion :)