### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ final class StubUserService: UserServiceProtocol {
 }
 
 func testMethodCall() {
+  // given 
   let userService = StubUserService()
   Stubber.register(userService.follow) { userID in "stub-\(userID)" } // stub
-  Stubber.follow(userID: 123) // call
+  
+  // when
+  userService.follow(userID: 123) // call
+  
+  // then
   XCTAssertEqual(Stubber.executions(userService.follow).count, 1)
   XCTAssertEqual(Stubber.executions(userService.follow)[0].arguments, 123)
   XCTAssertEqual(Stubber.executions(userService.follow)[0].result, "stub-123")


### PR DESCRIPTION
1. I guess `Stubber.follow` should be `userService.follow`, that's why I propose this PR.

2. And there is another proposition. `given,when,then` comments can improve readability and make clear of this repo's goal. (which makes testing easier in given stage, and furthermore, changes will only happen in that part.)