### PR TITLE
Fix a crash when stubbing an object with a closure

### DIFF
--- a/Sources/Stubber/Execution.swift
+++ b/Sources/Stubber/Execution.swift
@@ -2,6 +2,6 @@ public protocol AnyExecution {
 }
 
 public struct Execution<A, R>: AnyExecution {
-  public let arguments: A
+  public let arguments: A!
   public let result: R
 }

--- a/Tests/StubberTests/StubberTests.swift
+++ b/Tests/StubberTests/StubberTests.swift
@@ -208,4 +208,22 @@ class StubberTests: XCTestCase {
     }
     XCTWaiter().wait(for: [XCTestExpectation()], timeout: 1)
   }
+
+  func testClosureCrash() {
+    // given
+    final class ImageManager {
+      func requestImage(for asset: AnyObject, resultHandler: (() -> Void)? = nil) {
+        return Stubber.invoke(requestImage, args: (asset, resultHandler), default: Void())
+      }
+    }
+
+    let imageManager = ImageManager()
+    imageManager.requestImage(for: NSObject())
+
+    let executions = Stubber.executions(imageManager.requestImage)
+
+    // crash
+    _ = executions.first?.arguments.0
+    Stubber.clear()
+  }
 }


### PR DESCRIPTION
From Xcode 11.4 Stubber crashes on `executions.removeAll()` when stubbing an object with a closure. I have no clue why this happens but found a workaround.