### PR TITLE
Fix a bug on argument nil check when using custom matcher

### DIFF
--- a/Sources/Stubber/Execution.swift
+++ b/Sources/Stubber/Execution.swift
@@ -2,6 +2,15 @@ public protocol AnyExecution {
 }
 
 public struct Execution<A, R>: AnyExecution {
-  public let arguments: A!
+  private let _arguments: A
+  public var arguments: A {
+    return self._arguments
+  }
+
   public let result: R
+
+  init(arguments: A, result: R) {
+    self._arguments = arguments
+    self.result = result
+  }
 }

--- a/Tests/StubberTests/StubberTests.swift
+++ b/Tests/StubberTests/StubberTests.swift
@@ -226,4 +226,25 @@ class StubberTests: XCTestCase {
     _ = executions.first?.arguments.0
     Stubber.clear()
   }
+
+  func testMatcherArgumentNil() {
+    // given
+    final class Foo {
+      func doSomething(with arg: String?) {
+        Stubber.invoke(doSomething(with:), args: arg, default: Void())
+      }
+    }
+
+    func expect<T>(_ value: T, toHaveCount count: Int, file: StaticString = #file, line: UInt = #line, where: @escaping (T.Iterator.Element) -> Bool) where T: Collection {
+      XCTAssertEqual(value.filter(`where`).count, count, file: file, line: line)
+    }
+
+    let foo = Foo()
+    foo.doSomething(with: nil)
+
+    let executions = Stubber.executions(foo.doSomething(with:))
+    expect(executions, toHaveCount: 1) {
+      $0.arguments == nil
+    }
+  }
 }


### PR DESCRIPTION
After #6, I found an issue on arguments nil checking. This workaround fixes both #6 and the new issue.